### PR TITLE
deleted redundant #include directive

### DIFF
--- a/src/scpptool.cpp
+++ b/src/scpptool.cpp
@@ -11,7 +11,6 @@
 /*Standard headers*/
 #include <string>
 #include <iostream>
-#include <string>
 #include <vector>
 #include <map>
 #include <unordered_map>


### PR DESCRIPTION
you include <string> twice in scpptool.cpp